### PR TITLE
Remove invalid `:dependent` option for `t.references`

### DIFF
--- a/db/migrate/20200816132057_devise_create_user_database_authentications.rb
+++ b/db/migrate/20200816132057_devise_create_user_database_authentications.rb
@@ -3,7 +3,7 @@
 class DeviseCreateUserDatabaseAuthentications < ActiveRecord::Migration[6.0]
   def change
     create_table :user_database_authentications do |t|
-      t.references :user, foreign_key: true, dependent: :destroy,  index: {unique: true}
+      t.references :user, foreign_key: true, index: {unique: true}
       ## Database authenticatable
       t.string :email,              null: false
       t.string :encrypted_password, null: false


### PR DESCRIPTION
Valid options are `:type`, `:index`, `:foreign_key`, `:polymorphic`, and `:null`.

https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-references
https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_reference